### PR TITLE
Adds dc:issued to all extensions ensuring they validate

### DIFF
--- a/extension/distribution.xml
+++ b/extension/distribution.xml
@@ -8,6 +8,7 @@
     namespace="http://purl.org/pliniancore/terms" 
     rowType="http://purl.org/pliniancore/terms/DistributionClass"
     dc:subject="dwc:Taxon; plic:Distribution"
+    dc:issued="2015-05-20"
     dc:relation="https://github.com/PlinianCore/Documentation/wiki/DistributionClass"
     dc:description="Species geographical  distribution.">
 	

--- a/extension/endemic.xml
+++ b/extension/endemic.xml
@@ -8,6 +8,7 @@
     namespace="http://purl.org/pliniancore/terms" 
     rowType="http://purl.org/pliniancore/terms/EndemicAtomizedClass"
     dc:subject="dwc:Taxon; plic:Endemic"
+    dc:issued="2015-05-20"
     dc:relation="https://github.com/PlinianCore/Documentation/wiki/EndemicAtomizedClass"
     dc:description="Organism that lives exclusively in a particular territory and not found anywhere else.">
 	

--- a/extension/legislation.xml
+++ b/extension/legislation.xml
@@ -8,6 +8,7 @@
     namespace="http://purl.org/pliniancore/terms" 
     rowType="http://purl.org/pliniancore/terms/LegislationAtomizedClass"
     dc:subject="dwc:Taxon; plic:Legislation"
+    dc:issued="2015-05-20"
     dc:relation="https://github.com/PlinianCore/Documentation/wiki/LegislationAtomizedClass"
     dc:description="A national proposed law or group of laws. A regional proposed law or group of laws.">
     

--- a/extension/managementAndConservation.xml
+++ b/extension/managementAndConservation.xml
@@ -8,6 +8,7 @@
     namespace="http://purl.org/pliniancore/terms" 
     rowType="http://purl.org/pliniancore/terms/ManagementAndConservationAtomizedClass"
     dc:subject="dwc:Taxon; plic:ManagementAndConservation"
+    dc:issued="2015-05-20"
     dc:relation="https://github.com/PlinianCore/Documentation/wiki/ManagementAndConservationAtomizedClass"
     dc:description="Management: actions directed at conserving or restoring species / Conservation: interventions undertaken designed to preserve species.">
 	

--- a/extension/pliniancore.xml
+++ b/extension/pliniancore.xml
@@ -8,6 +8,7 @@
     namespace="http://purl.org/pliniancore/terms" 
     rowType="http://purl.org/pliniancore/terms/PlinianCoreTaxon"
     dc:subject="plic:Plinian Core; dwc:Taxon"
+    dc:issued="2015-05-20"
     dc:relation="https://github.com/PlinianCore/Documentation/wiki/TaxonRecordClass"
     dc:description="The Plinian Core is a set of concepts that defines the necessary basic attributes to integrate and recover the information about species of organisms required by users specialized in biodiversity as well as users of other areas. This extension is supposed to be used in addition to the taxon core and the simple images, vernacular names and references extension.">
 

--- a/extension/synonyms.xml
+++ b/extension/synonyms.xml
@@ -8,6 +8,7 @@
     namespace="http://purl.org/pliniancore/terms" 
     rowType="http://purl.org/pliniancore/terms/SynonymsAtomizedClass"
     dc:subject="dwc:Taxon; plic:Synonyms"
+    dc:issued="2015-05-20"
     dc:relation="https://github.com/PlinianCore/Documentation/wiki/SynonymsAtomizedClass"
     dc:description="Different names for this taxon. This concept is a placeholder field.">
 	

--- a/extension/threatStatus.xml
+++ b/extension/threatStatus.xml
@@ -8,6 +8,7 @@
     namespace="http://purl.org/pliniancore/terms" 
     rowType="http://purl.org/pliniancore/terms/ThreatStatusAtomizedClass"
     dc:subject="dwc:Taxon; plic:threatStatus"
+    dc:issued="2015-05-20"
     dc:relation="https://github.com/PlinianCore/Documentation/wiki/ThreatStatusAtomizedClass"
     dc:description="Information about the status of the taxon.">
     

--- a/extension/uses.xml
+++ b/extension/uses.xml
@@ -8,6 +8,7 @@
     namespace="http://purl.org/pliniancore/terms" 
     rowType="http://purl.org/pliniancore/terms/UsesAtomizedClass"
     dc:subject="dwc:Taxon; plic:Uses"
+    dc:issued="2015-05-20"
     dc:relation="https://github.com/PlinianCore/Documentation/wiki/UsesAtomizedClass"
     dc:description="Ways in which species are utilized by people. Including Folklore">
 	


### PR DESCRIPTION
Pull request adds dc:issued date to all extensions. 

I used '2015-05-20' as an example date. 

Please note, dc:issued is a required attribute as per the [Extension XSD](http://rs.gbif.org/schema/extension.xsd). Currently these extensions don't validate because they are missing this attribute. The pull request ensures all extensions will validate.

Please also note that all extensions registered with GBIF must validate. This ensures they can be successfully integrated into the IPT's (JSON) extensions lists. Currently these extensions appear in the [IPT's sandbox extensions list](http://gbrdsdev.gbif.org/registry/extensions.json).
